### PR TITLE
Fix issue with environment variables

### DIFF
--- a/mongodb-gui-keycloak/docker-compose.yaml
+++ b/mongodb-gui-keycloak/docker-compose.yaml
@@ -1,21 +1,28 @@
 version: '3'
 services:
   mongodb:
-    image: mongo:3.2
+    image: mongo
     ports: 
       - 27017:27017
     environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: example
-    volumes:
-      - ./mongo:/data/db
+    - MONGO_INITDB_ROOT_USERNAME=root
+    - MONGO_INITDB_ROOT_PASSWORD=example
+    - MONGO_INITDB_DATABASE=example
   
   mongo-express:
     image: mongo-express
     ports:
-      - 8081:8081
+      - 8888:8081
     environment:
-      ME_CONFIG_MONGODB_ADMINUSERNAME: root
-      ME_CONFIG_MONGODB_ADMINPASSWORD: example
-      ME_CONFIG_MONGODB_SERVER: mongodb
+    - ME_CONFIG_MONGODB_SERVER=mongodb
+    - ME_CONFIG_MONGODB_PORT=27017
+    - ME_CONFIG_MONGODB_ENABLE_ADMIN=true
+    - ME_CONFIG_MONGODB_AUTH_DATABASE=admin
+    - ME_CONFIG_MONGODB_AUTH_USERNAME=root
+    - ME_CONFIG_MONGODB_AUTH_PASSWORD=example
+    - ME_CONFIG_BASICAUTH_USERNAME=root
+    - ME_CONFIG_BASICAUTH_PASSWORD=example
+    depends_on:
+      - mongodb
+
 


### PR DESCRIPTION
Environment variables should be added as string.
With the volumn option the connection between mongo-express and mongo does not succeed.